### PR TITLE
Many fixes

### DIFF
--- a/softcut-test.maxpat
+++ b/softcut-test.maxpat
@@ -4,13 +4,13 @@
 		"appversion" : 		{
 			"major" : 8,
 			"minor" : 0,
-			"revision" : 1,
+			"revision" : 2,
 			"architecture" : "x64",
 			"modernui" : 1
 		}
 ,
 		"classnamespace" : "box",
-		"rect" : [ 106.0, 98.0, 853.0, 768.0 ],
+		"rect" : [ 34.0, 79.0, 760.0, 787.0 ],
 		"bglocked" : 0,
 		"openinpresentation" : 0,
 		"default_fontsize" : 12.0,
@@ -38,6 +38,104 @@
 		"style" : "",
 		"subpatcher_template" : "",
 		"boxes" : [ 			{
+				"box" : 				{
+					"id" : "obj-54",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 185.0, 650.0, 98.0, 22.0 ],
+					"text" : "rec_offset -0.001"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-51",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 117.0, 640.0, 44.0, 22.0 ],
+					"text" : "play 0."
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-50",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 505.0, 668.0, 109.0, 22.0 ],
+					"text" : "prepend fade_time"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"format" : 6,
+					"id" : "obj-43",
+					"maxclass" : "flonum",
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"outlettype" : [ "", "bang" ],
+					"parameter_enable" : 0,
+					"patching_rect" : [ 541.0, 581.0, 50.0, 22.0 ]
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-36",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 616.0, 581.0, 75.0, 22.0 ],
+					"text" : "fade_time 1."
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-31",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 610.0, 707.0, 77.0, 22.0 ],
+					"text" : "prepend rate"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"format" : 6,
+					"id" : "obj-29",
+					"maxclass" : "flonum",
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"outlettype" : [ "", "bang" ],
+					"parameter_enable" : 0,
+					"patching_rect" : [ 618.0, 655.0, 50.0, 22.0 ]
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-20",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 350.0, 9.0, 33.0, 22.0 ],
+					"text" : "read"
+				}
+
+			}
+, 			{
 				"box" : 				{
 					"id" : "obj-35",
 					"maxclass" : "comment",
@@ -178,8 +276,8 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 605.0, 449.0, 60.0, 22.0 ],
-					"text" : "position 0"
+					"patching_rect" : [ 605.0, 449.0, 70.0, 22.0 ],
+					"text" : "position 2.4"
 				}
 
 			}
@@ -237,8 +335,8 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 411.0, 445.0, 75.0, 22.0 ],
-					"text" : "loop_start 0."
+					"patching_rect" : [ 411.0, 445.0, 71.0, 22.0 ],
+					"text" : "loop_start 1"
 				}
 
 			}
@@ -261,8 +359,8 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 439.0, 476.0, 81.0, 22.0 ],
-					"text" : "loop_end 174"
+					"patching_rect" : [ 439.0, 476.0, 68.0, 22.0 ],
+					"text" : "loop_end 3"
 				}
 
 			}
@@ -334,7 +432,7 @@
 					"numoutlets" : 2,
 					"outlettype" : [ "signal", "" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 7.0, 236.0, 156.0, 29.0 ]
+					"patching_rect" : [ 14.0, 232.0, 156.0, 29.0 ]
 				}
 
 			}
@@ -392,8 +490,8 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "float", "bang" ],
-					"patching_rect" : [ 7.0, 9.0, 109.0, 22.0 ],
-					"text" : "buffer~ b 174763 1"
+					"patching_rect" : [ 7.0, 9.0, 96.0, 22.0 ],
+					"text" : "buffer~ b 4000 1"
 				}
 
 			}
@@ -431,14 +529,6 @@
 				"patchline" : 				{
 					"destination" : [ "obj-11", 0 ],
 					"source" : [ "obj-10", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-12", 0 ],
-					"order" : 8,
-					"source" : [ "obj-11", 0 ]
 				}
 
 			}
@@ -485,7 +575,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-26", 0 ],
-					"order" : 12,
+					"order" : 11,
 					"source" : [ "obj-11", 0 ]
 				}
 
@@ -509,14 +599,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-34", 0 ],
-					"order" : 11,
-					"source" : [ "obj-11", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-37", 0 ],
 					"order" : 10,
 					"source" : [ "obj-11", 0 ]
 				}
@@ -524,8 +606,16 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-39", 0 ],
+					"destination" : [ "obj-37", 0 ],
 					"order" : 9,
+					"source" : [ "obj-11", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-39", 0 ],
+					"order" : 8,
 					"source" : [ "obj-11", 0 ]
 				}
 
@@ -535,6 +625,13 @@
 					"destination" : [ "obj-9", 0 ],
 					"order" : 6,
 					"source" : [ "obj-11", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-28", 0 ],
+					"source" : [ "obj-12", 0 ]
 				}
 
 			}
@@ -593,6 +690,13 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-2", 0 ],
+					"source" : [ "obj-20", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-28", 0 ],
 					"source" : [ "obj-21", 0 ]
 				}
@@ -635,6 +739,13 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-31", 0 ],
+					"source" : [ "obj-29", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-17", 0 ],
 					"source" : [ "obj-3", 0 ]
 				}
@@ -644,6 +755,13 @@
 				"patchline" : 				{
 					"destination" : [ "obj-28", 0 ],
 					"source" : [ "obj-30", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-28", 0 ],
+					"source" : [ "obj-31", 0 ]
 				}
 
 			}
@@ -664,6 +782,13 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-28", 0 ],
+					"source" : [ "obj-36", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-28", 0 ],
 					"source" : [ "obj-37", 0 ]
 				}
 
@@ -672,6 +797,34 @@
 				"patchline" : 				{
 					"destination" : [ "obj-28", 0 ],
 					"source" : [ "obj-39", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-50", 0 ],
+					"source" : [ "obj-43", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-28", 0 ],
+					"source" : [ "obj-50", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-28", 0 ],
+					"source" : [ "obj-51", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-28", 0 ],
+					"source" : [ "obj-54", 0 ]
 				}
 
 			}

--- a/softcut-test.maxpat
+++ b/softcut-test.maxpat
@@ -10,7 +10,7 @@
 		}
 ,
 		"classnamespace" : "box",
-		"rect" : [ 34.0, 79.0, 760.0, 787.0 ],
+		"rect" : [ 34.0, 79.0, 1163.0, 787.0 ],
 		"bglocked" : 0,
 		"openinpresentation" : 0,
 		"default_fontsize" : 12.0,
@@ -38,6 +38,171 @@
 		"style" : "",
 		"subpatcher_template" : "",
 		"boxes" : [ 			{
+				"box" : 				{
+					"id" : "obj-40",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 1009.0, 144.0, 84.0, 22.0 ],
+					"text" : "filter_fc 12000"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-6",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 928.0, 501.0, 109.0, 22.0 ],
+					"text" : "rate_slew_time 0.8"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-59",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 778.0, 706.0, 29.5, 22.0 ],
+					"text" : "-1.8"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-57",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 699.0, 635.0, 29.5, 22.0 ],
+					"text" : "2"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-55",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 808.0, 597.0, 50.0, 22.0 ],
+					"text" : "send sc"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-42",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 875.0, 566.0, 120.0, 22.0 ],
+					"text" : "level_slew_time 0.01"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-38",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 798.0, 501.0, 115.0, 22.0 ],
+					"text" : "rate_slew_time 0.2"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-52",
+					"maxclass" : "comment",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 814.0, 108.0, 150.0, 20.0 ],
+					"text" : "'antialiasing' filter setup"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-48",
+					"maxclass" : "button",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "bang" ],
+					"parameter_enable" : 0,
+					"patching_rect" : [ 825.0, 148.0, 24.0, 24.0 ]
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-46",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 932.0, 268.0, 59.0, 22.0 ],
+					"text" : "filter_rq 1"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-44",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 774.0, 235.5, 57.0, 22.0 ],
+					"text" : "filter_lp 1"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-41",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 896.0, 188.0, 65.0, 22.0 ],
+					"text" : "filter_dry 0"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-33",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 892.0, 366.0, 50.0, 22.0 ],
+					"text" : "send sc"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-25",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 873.5, 157.5, 87.0, 22.0 ],
+					"text" : "filter_fc_mod 1"
+				}
+
+			}
+, 			{
 				"box" : 				{
 					"id" : "obj-54",
 					"maxclass" : "message",
@@ -359,7 +524,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 439.0, 476.0, 68.0, 22.0 ],
+					"patching_rect" : [ 411.0, 478.0, 68.0, 22.0 ],
 					"text" : "loop_end 3"
 				}
 
@@ -383,7 +548,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "float" ],
-					"patching_rect" : [ 147.0, 141.0, 80.0, 13.0 ]
+					"patching_rect" : [ 245.0, 162.0, 80.0, 13.0 ]
 				}
 
 			}
@@ -725,6 +890,13 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-33", 0 ],
+					"source" : [ "obj-25", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-28", 0 ],
 					"source" : [ "obj-26", 0 ]
 				}
@@ -795,6 +967,13 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-55", 0 ],
+					"source" : [ "obj-38", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-28", 0 ],
 					"source" : [ "obj-39", 0 ]
 				}
@@ -802,8 +981,75 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-33", 0 ],
+					"source" : [ "obj-40", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-33", 0 ],
+					"source" : [ "obj-41", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-55", 0 ],
+					"source" : [ "obj-42", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-50", 0 ],
 					"source" : [ "obj-43", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-33", 0 ],
+					"source" : [ "obj-44", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-33", 0 ],
+					"source" : [ "obj-46", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-25", 0 ],
+					"order" : 2,
+					"source" : [ "obj-48", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-41", 0 ],
+					"order" : 1,
+					"source" : [ "obj-48", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-44", 0 ],
+					"order" : 3,
+					"source" : [ "obj-48", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-46", 0 ],
+					"order" : 0,
+					"source" : [ "obj-48", 0 ]
 				}
 
 			}
@@ -825,6 +1071,27 @@
 				"patchline" : 				{
 					"destination" : [ "obj-28", 0 ],
 					"source" : [ "obj-54", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-29", 0 ],
+					"source" : [ "obj-57", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-29", 0 ],
+					"source" : [ "obj-59", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-55", 0 ],
+					"source" : [ "obj-6", 0 ]
 				}
 
 			}

--- a/softcut-test.maxpat
+++ b/softcut-test.maxpat
@@ -39,6 +39,18 @@
 		"subpatcher_template" : "",
 		"boxes" : [ 			{
 				"box" : 				{
+					"id" : "obj-45",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 756.0, 655.0, 29.5, 22.0 ],
+					"text" : "3.2"
+				}
+
+			}
+, 			{
+				"box" : 				{
 					"id" : "obj-40",
 					"maxclass" : "message",
 					"numinlets" : 2,
@@ -150,8 +162,8 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 932.0, 268.0, 59.0, 22.0 ],
-					"text" : "filter_rq 1"
+					"patching_rect" : [ 932.0, 268.0, 69.0, 22.0 ],
+					"text" : "filter_rq 0.5"
 				}
 
 			}
@@ -1011,6 +1023,13 @@
 				"patchline" : 				{
 					"destination" : [ "obj-33", 0 ],
 					"source" : [ "obj-44", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-29", 0 ],
+					"source" : [ "obj-45", 0 ]
 				}
 
 			}

--- a/softcut~.cpp
+++ b/softcut~.cpp
@@ -35,22 +35,6 @@ typedef struct _softcut {
     int bufFrames;
 } t_softcut;
 
-// used to round buffer length in samples to a power of 2
-int highestPowerof2(int n)
-{
-    int res = 0;
-    for (int i=n; i>=1; i--)
-    {
-        // If i is a power of 2
-        if ((i & (i-1)) == 0)
-        {
-            res = i;
-            break;
-        }
-    }
-    return res;
-}
-
 ///////////
 /// methods copied from SDK example
 void softcut_perform64(t_softcut *x, t_object *dsp64, double **ins, long numins, double **outs, long numouts, long sampleframes, long flags, void *userparam);
@@ -198,7 +182,6 @@ void softcut_perform64(t_softcut *x, t_object *dsp64, double **ins, long numins,
     t_double	*in = ins[0];
     t_double	*out = outs[0];
     
-    int nf;
     int			n = sampleframes;
     float		*tab;
     t_buffer_obj *buffer = buffer_ref_getobject(x->l_buffer_reference);
@@ -208,10 +191,8 @@ void softcut_perform64(t_softcut *x, t_object *dsp64, double **ins, long numins,
         goto zero;
     }
     
-    nf = highestPowerof2(buffer_getframecount(buffer));
-
     // FIXME? assuming buffer is mono.
-    x->scv.setBuffer(tab, nf);
+    x->scv.setBuffer(tab, buffer_getframecount(buffer));
 
 //#if 1
     for (int i=0; i<n; ++i) { x->inBuf[i] = (float)(*in++); }

--- a/softcut~.cpp
+++ b/softcut~.cpp
@@ -19,7 +19,6 @@
 using softcut::FadeCurves;
 
 #define SOFTCUT_IO_BUF_FRAMES 1024
-//#define SOFTCUT_BUF_FRAMES 8388608 //2^23 samples ~= 174.762667 seconds @48khz SR. set max buffer to 174763ms & SR = 48k
 
 typedef struct _softcut {
     t_pxobject l_obj;
@@ -121,10 +120,6 @@ void softcut_pre_level(t_softcut *sc, double val) {
     post("softcut_pre_level( %f )", val);
     sc->scv.setPreLevel(val);
 }
-void softcut_rec_offset(t_softcut *sc, double val) {
-    post("softcut_rec_offset( %f )", val);
-    sc->scv.setRecOffset(val);
-}
 void softcut_level_slew_time(t_softcut *sc, double val) {
     post("softcut_level_slew_time( %f )", val);
     sc->scv.setLevelSlewTime(val);
@@ -149,7 +144,6 @@ void ext_main(void *r)
     // set buffer
     class_addmethod(c, (method)softcut_set, "set", A_SYM, 0);
     
-    
     //--- softcut methods
     class_addmethod(c, (method)softcut_filter_fc, "filter_fc", A_FLOAT, 0);
     class_addmethod(c, (method)softcut_filter_fc_mod, "filter_fc_mod", A_FLOAT, 0);
@@ -169,7 +163,6 @@ void ext_main(void *r)
     class_addmethod(c, (method)softcut_rec, "rec", A_FLOAT, 0);
     class_addmethod(c, (method)softcut_rec_level, "rec_level", A_FLOAT, 0);
     class_addmethod(c, (method)softcut_pre_level, "pre_level", A_FLOAT, 0);
-    class_addmethod(c, (method)softcut_rec_offset, "rec_offset", A_FLOAT, 0);
     class_addmethod(c, (method)softcut_level_slew_time, "level_slew_time", A_FLOAT, 0);
     class_addmethod(c, (method)softcut_rate_slew_time, "rate_slew_time", A_FLOAT, 0);
     class_dspinit(c);
@@ -194,16 +187,13 @@ void softcut_perform64(t_softcut *x, t_object *dsp64, double **ins, long numins,
     // FIXME? assuming buffer is mono.
     x->scv.setBuffer(tab, buffer_getframecount(buffer));
 
-//#if 1
     for (int i=0; i<n; ++i) { x->inBuf[i] = (float)(*in++); }
     x->scv.processBlockMono(x->inBuf, x->outBuf, n);
-    for (int i=0; i<n; ++i) { *out++ = (x->outBuf[i]); }
-//#else
-//    /// testing... ok, skip the conversion?
-//    // in that case we probably want to zero the output first
-//    for (int i=0; i<n; ++i) { out[i] = 0.0; }
-//    x->scv.processBlockMono(src, dst, n);
-//#endif
+    if (x->scv.getPlayFlag()) {
+        for (int i=0; i<n; ++i) { *out++ = (x->outBuf[i]); }
+    } else {
+        for (int i=0; i<n; ++i) { *out++ = 0.f; }
+    }
     
     buffer_setdirty(buffer);
     buffer_unlocksamples(buffer);
@@ -270,8 +260,8 @@ void *softcut_new(t_symbol *s, long chan)
     FadeCurves::setRecDelayRatio(1.f/(8*16));
     
     // there should be a small negative offset, putting rec head behind play head
-    // shouldbe just big enough to keep resampling windows apart
-    x->scv.setRecOffset(-0.0004);
+    // should be just big enough to keep resampling windows apart
+    x->scv.setRecOffset(8.0 / x->scv.getSampleRate());
     
     return (x);
 }

--- a/softcut~.cpp
+++ b/softcut~.cpp
@@ -234,7 +234,7 @@ void softcut_dsp64(t_softcut *x, t_object *dsp64, short *count, double samplerat
     
     // there should be a small negative offset, putting rec head behind play head
     // should be just big enough to keep resampling windows apart
-    x->scv.setRecOffset(-32.0 / samplerate);
+    x->scv.setRecOffset(-12.0 / samplerate);
 }
 
 // this lets us double-click on softcut~ to open up the buffer~ it references
@@ -265,9 +265,6 @@ void *softcut_new(t_symbol *s, long chan)
     outlet_new((t_object *)x, "signal");
     // set buffer reference using argument
     softcut_set(x, s);
-    
-    // WTF!
-    x->scv.setRecOffset(-0.001);
     
     return (x);
 }

--- a/softcut~.xcodeproj/project.pbxproj
+++ b/softcut~.xcodeproj/project.pbxproj
@@ -97,23 +97,23 @@
 		81BB914122A612C700718B52 /* src */ = {
 			isa = PBXGroup;
 			children = (
-				81BB914222A612C700718B52 /* TestBuffers.h */,
-				81BB914322A612C700718B52 /* Svf.cpp */,
-				81BB914422A612C700718B52 /* Types.h */,
-				81BB914522A612C700718B52 /* SubHead.h */,
-				81BB914622A612C700718B52 /* SoftCutVoice.cpp */,
 				81BB914722A612C700718B52 /* FadeCurves.cpp */,
 				81BB914822A612C700718B52 /* FadeCurves.h */,
-				81BB914922A612C700718B52 /* SoftCutHead.cpp */,
-				81BB914A22A612C700718B52 /* SoftClip.h */,
-				81BB914B22A612C700718B52 /* SoftCutHead.h */,
 				81BB914C22A612C700718B52 /* Interpolate.h */,
-				81BB914D22A612C700718B52 /* SoftCutVoice.h */,
-				81BB914E22A612C700718B52 /* Svf.h */,
-				81BB914F22A612C700718B52 /* Resampler.h */,
 				81BB915122A612C700718B52 /* LowpassBrickwall.h */,
+				81BB914F22A612C700718B52 /* Resampler.h */,
+				81BB914A22A612C700718B52 /* SoftClip.h */,
 				81BB915222A612C700718B52 /* SoftCut.h */,
+				81BB914B22A612C700718B52 /* SoftCutHead.h */,
+				81BB914922A612C700718B52 /* SoftCutHead.cpp */,
+				81BB914D22A612C700718B52 /* SoftCutVoice.h */,
+				81BB914622A612C700718B52 /* SoftCutVoice.cpp */,
+				81BB914522A612C700718B52 /* SubHead.h */,
 				81BB915322A612C700718B52 /* SubHead.cpp */,
+				81BB914E22A612C700718B52 /* Svf.h */,
+				81BB914322A612C700718B52 /* Svf.cpp */,
+				81BB914222A612C700718B52 /* TestBuffers.h */,
+				81BB914422A612C700718B52 /* Types.h */,
 			);
 			path = src;
 			sourceTree = "<group>";

--- a/src/Resampler.h
+++ b/src/Resampler.h
@@ -116,8 +116,6 @@ namespace softcut {
                                                                        inBuf_[i3]));
 #endif
         }
-
-
         // write, upsampling
         // return frames written (>= 1)
         // assumptions: input has been pushed. rate_ > 1.0

--- a/src/SoftCutVoice.cpp
+++ b/src/SoftCutVoice.cpp
@@ -150,9 +150,9 @@ void SoftCutVoice::setFilterFcMod(float x) {
 }
 
 void SoftCutVoice::updateFilterFc() {
-    float fc = std::min(fcBase, fcBase * std::fabs(static_cast<float>(sch.getRate())));
-    // std::cout << fc << std::endl;
-    svf.setFc(fc*fcMod + (1.f-fcMod )*svf.getFc());
+    float modVal = std::min(fcBase, fcBase * std::fabs(static_cast<float>(sch.getRate())));
+    modVal = fcBase + fcMod * (modVal - fcBase);
+    svf.setFc(fcMod);
 }
 
 void SoftCutVoice::setBuffer(float *b, unsigned int nf) {

--- a/src/SoftCutVoice.h
+++ b/src/SoftCutVoice.h
@@ -57,7 +57,7 @@ namespace softcut {
         bool getRecFlag();
 
         float getPos();
-
+        float getSampleRate() { return sampleRate; }
     private:
         void updateFilterFc();
         void updateQuantPhase();

--- a/src/SoftCutVoice.h
+++ b/src/SoftCutVoice.h
@@ -15,6 +15,10 @@
 namespace softcut {
     class SoftCutVoice {
     public:
+        static constexpr float maxRate = 32.f;
+        static constexpr float minRate = -32.f;
+        
+    public:
         SoftCutVoice();
         void setBuffer(float* buf, unsigned int numFrames);
 

--- a/src/SubHead.cpp
+++ b/src/SubHead.cpp
@@ -106,10 +106,7 @@ void SubHead::poke(float in, float pre, float rec, int numFades) {
     if(state_ == Inactive) {
         return;
     }
-
-    // BOOST_ASSERT_MSG(fade_ >= 0.f && fade_ <= 1.f, "bad fade coefficient in poke()");
-
-
+    
     preFade_ = pre + (1.f-pre) * FadeCurves::getPreFadeValue(fade_);
     recFade_ = rec * FadeCurves::getRecFadeValue(fade_);
     sample_t y; // write value
@@ -118,7 +115,7 @@ void SubHead::poke(float in, float pre, float rec, int numFades) {
     for(int i=0; i<nframes; ++i) {
         y = src[i];
 
-#if 0 // soft clipper
+#if 1 // soft clipper
         y = clip_.processSample(y);
 #endif
 #if 0 // lowpass filter
@@ -165,7 +162,6 @@ void SubHead::setSampleRate(float sr) {
 void SubHead::setPhase(phase_t phase) {
     phase_ = phase;
     wrIdx_ = wrapBufIndex(static_cast<int>(phase_) + (inc_dir_ * recOffset_));
-
     // NB: not resetting the resampler here:
     // - it's ok to keep history of input when changing positions.
     // - resamp output doesn't need clearing b/c we write/read from beginning on each sample anyway
@@ -183,7 +179,6 @@ void SubHead::setRate(rate_t rate) {
     // instead we copy the resampler output backwards into the buffer when rate < 0.
     resamp_.setRate(std::fabs(rate));
 }
-
 
 void SubHead::setState(State state) { state_ = state; }
 

--- a/src/SubHead.cpp
+++ b/src/SubHead.cpp
@@ -115,7 +115,7 @@ void SubHead::poke(float in, float pre, float rec, int numFades) {
     for(int i=0; i<nframes; ++i) {
         y = src[i];
 
-#if 1 // soft clipper
+#if 0 // soft clipper
         y = clip_.processSample(y);
 #endif
 #if 0 // lowpass filter

--- a/src/SubHead.cpp
+++ b/src/SubHead.cpp
@@ -152,9 +152,10 @@ float SubHead::peek4() {
 }
 
 unsigned int SubHead::wrapBufIndex(int x) {
-    x += bufFrames_;
-    // BOOST_ASSERT_MSG(x >= 0, "buffer index before masking is non-negative");
-    return x & bufMask_;
+    int y = x;
+    while (y < 0) { y += bufFrames_; }
+    while (y >= bufFrames_ ) { y -= bufFrames_; }
+    return y;
 }
 
 void SubHead::setSampleRate(float sr) {
@@ -170,13 +171,9 @@ void SubHead::setPhase(phase_t phase) {
     // - resamp output doesn't need clearing b/c we write/read from beginning on each sample anyway
 }
 
-// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-// **NB** buffer size must be a power of two!!!!
 void SubHead::setBuffer(float *buf, unsigned int frames) {
     buf_  = buf;
     bufFrames_ = frames;
-    bufMask_ = frames - 1;
-    // BOOST_ASSERT_MSG((bufFrames_ != 0) && !(bufFrames_ & bufMask_), "buffer size is not 2^N");
 }
 
 void SubHead::setRate(rate_t rate) {

--- a/src/SubHead.h
+++ b/src/SubHead.h
@@ -65,7 +65,6 @@ namespace softcut {
         sample_t* buf_; // output buffer
         unsigned int wrIdx_; // write index
         unsigned int bufFrames_;
-        unsigned int bufMask_;
 
         State state_;
         rate_t rate_;

--- a/src/Svf.cpp
+++ b/src/Svf.cpp
@@ -67,7 +67,7 @@ void Svf::svf_set_sr(t_svf* svf, float sr) {
 }
 
 void Svf::svf_set_fc(t_svf* svf, float fc) {
-    svf->fc = fc;
+    svf->fc = (fc > svf->sr / 2) ? svf->sr / 2 : fc;
     svf_calc_coeffs(svf);
 }
 

--- a/src/Utilities.h
+++ b/src/Utilities.h
@@ -32,7 +32,7 @@ namespace crone {
 // define this here for a consistent interpretation of pole coefficient
 // we use faust's definition where b=0 is instant, b in [0, 1)
     static float smooth1pole(float x, float x0, float b) {
-        // return x * (1.f - b) + b * x0;f
+        // return x * (1.f - b) + b * x0;
         // refactored
         return x + (x0 - x) * b;
     }
@@ -168,7 +168,7 @@ namespace crone {
         void setTarget(float x) {
             x0 = x;
         }
-
+        
         // update output only
         float update() {
             y0 = smooth1pole(x0, y0, b);


### PR DESCRIPTION
- no longer requires 2^N frames buffer
- record offset initialized more correctly (doesn't glitch at non-integer write speeds), and can't be modulated (it's more dangerous than useful.)
- silence output when play is disabled
- clamp rate to +/- 32 so it doesn't crash Max
- clamp SVF freq to 1/2 nyquist so it doesn't explode
- update filter with per-sample rate change
- fix filer modulation algo.

still TODO:

- make a much nicer actual help patcher
- phase output. dunno if this should be a second audio signal (unquantized, like `groove~` sync), or a message outlet that bangs when quantized phase updates (like norns poll)
- filter modulation helps with aliasing, but sweeping through zero rate (while writing) still causes rate spike that feels like a mistake (when playing back.) fix this with write-amplitude dead zone around rate==0.
- soft clipper function returns `-0` always. no idea why (it works on the norns and the math looks fine.) disabled for now.